### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "goff",
   "type": "module",
   "version": "0.0.5",
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@11.1.2",
   "description": "",
   "license": "MIT",
   "repository": "danielroe/goff",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
   - playground
 
+allowBuilds:
+  esbuild: false
+  simple-git-hooks: false
+
 overrides:
   goff: 'link:.'


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`