### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,16 +47,16 @@
     "yaml": "^2.4.1"
   },
   "devDependencies": {
-    "@antfu/eslint-config": "latest",
+    "@antfu/eslint-config": "^9.1.0",
     "@types/node": "24.13.2",
-    "@vitest/coverage-v8": "latest",
-    "eslint": "latest",
+    "@vitest/coverage-v8": "^4.1.10",
+    "eslint": "^10.6.0",
     "nano-staged": "1.0.2",
-    "simple-git-hooks": "latest",
+    "simple-git-hooks": "^2.13.1",
     "tsdown": "0.22.3",
-    "typescript": "latest",
-    "vite": "latest",
-    "vitest": "latest"
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3",
+    "vitest": "^4.1.10"
   },
   "simple-git-hooks": {
     "pre-commit": "npx nano-staged"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,34 +37,34 @@ importers:
         version: 2.9.0
     devDependencies:
       '@antfu/eslint-config':
-        specifier: latest
+        specifier: ^9.1.0
         version: 9.1.0(@typescript-eslint/rule-tester@8.56.1(eslint@10.6.0(jiti@2.6.1))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.62.0(typescript@6.0.3))(@typescript-eslint/utils@8.62.0(eslint@10.6.0(jiti@2.6.1))(typescript@6.0.3))(@vue/compiler-sfc@3.5.26)(eslint@10.6.0(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.10)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
       '@vitest/coverage-v8':
-        specifier: latest
+        specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
       eslint:
-        specifier: latest
+        specifier: ^10.6.0
         version: 10.6.0(jiti@2.6.1)
       nano-staged:
         specifier: 1.0.2
         version: 1.0.2
       simple-git-hooks:
-        specifier: latest
+        specifier: ^2.13.1
         version: 2.13.1
       tsdown:
         specifier: 0.22.3
         version: 0.22.3(typescript@6.0.3)
       typescript:
-        specifier: latest
+        specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: latest
+        specifier: ^8.1.3
         version: 8.1.3(@types/node@24.13.2)(jiti@2.6.1)(yaml@2.9.0)
       vitest:
-        specifier: latest
+        specifier: ^4.1.10
         version: 4.1.10(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@24.13.2)(jiti@2.6.1)(yaml@2.9.0))
 
   playground:


### PR DESCRIPTION
`latest` is a curse and can easily drift, or change wildly on lockfile regeneration